### PR TITLE
Add option for a configurable Helm repo

### DIFF
--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- if .Values.serviceCatalogEnabledOnly }}
         - --service-catalog-enabled-only
         {{- end }}
+        {{- if .Values.helmRepoUrl }}
+        - -helmUrl
+        - "{{ .Values.helmRepoUrl }}"
+        {{- end }}
         - --port
         - "8080"
         {{- if .Values.tls.cert }}

--- a/cmd/minibroker/main.go
+++ b/cmd/minibroker/main.go
@@ -38,6 +38,8 @@ func init() {
 		"base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
 	flag.StringVar(&options.CatalogPath, "catalogPath", "",
 		"The path to the catalog")
+	flag.StringVar(&options.HelmRepoUrl, "helmUrl", "",
+		"The url to the helm repo")
 	flag.Parse()
 }
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -13,7 +13,7 @@ import (
 // with. NewBroker is the place where you will initialize your
 // Broker the parameters passed in.
 func NewBroker(o Options) (*Broker, error) {
-	mb := minibroker.NewClient("", o.ServiceCatalogEnabledOnly)
+	mb := minibroker.NewClient(o.HelmRepoUrl, o.ServiceCatalogEnabledOnly)
 	err := mb.Init()
 	if err != nil {
 		return nil, err

--- a/pkg/broker/options.go
+++ b/pkg/broker/options.go
@@ -1,6 +1,7 @@
 package broker
 
 type Options struct {
+	HelmRepoUrl               string
 	CatalogPath               string
 	ServiceCatalogEnabledOnly bool
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -46,7 +46,7 @@ func (c *Client) Init() error {
 	cr := repo.Entry{
 		Name:  "stable",
 		Cache: cif,
-		URL:   stableURL,
+		URL:   c.repoURL,
 	}
 
 	var settings environment.EnvSettings
@@ -56,7 +56,7 @@ func (c *Client) Init() error {
 	}
 
 	if err := r.DownloadIndexFile(c.home.Cache()); err != nil {
-		return errors.Wrapf(err, "Looks like %q is not a valid chart repository or cannot be reached", stableURL)
+		return errors.Wrapf(err, "Looks like %q is not a valid chart repository or cannot be reached", cr.URL)
 	}
 
 	f.Update(&cr)


### PR DESCRIPTION
We would like to use a staging registry for services that we're working on rather than the official charts repo.

This PR adds a command line option to the broker that's configured during a helm install of the broker itself.