### PR TITLE
Get helm chart's keywords to use as broker tags

### DIFF
--- a/pkg/minibroker/minibroker_test.go
+++ b/pkg/minibroker/minibroker_test.go
@@ -21,7 +21,7 @@ func TestHasTag(t *testing.T) {
 	for _, tt := range tagTests {
 		actual := hasTag(tt.tag, tt.list)
 		if actual != tt.expected {
-			t.Errorf("hasTag(%s %v): expected %s, actual %s",
+			t.Errorf("hasTag(%s %v): expected %t, actual %t",
 				tt.tag, tt.list, tt.expected, actual)
 		}
 	}

--- a/pkg/minibroker/minibroker_test.go
+++ b/pkg/minibroker/minibroker_test.go
@@ -1,1 +1,88 @@
 package minibroker
+
+import (
+	"testing"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/repo"
+)
+
+func TestHasTag(t *testing.T) {
+	tagTests := []struct {
+		tag      string
+		list     []string
+		expected bool
+	}{
+		{"foo", []string{"foo", "bar"}, true},
+		{"foo", []string{"bar", "baz"}, false},
+		{"foo", []string{}, false},
+	}
+
+	for _, tt := range tagTests {
+		actual := hasTag(tt.tag, tt.list)
+		if actual != tt.expected {
+			t.Errorf("hasTag(%s %v): expected %s, actual %s",
+				tt.tag, tt.list, tt.expected, actual)
+		}
+	}
+}
+
+func TestGetTagIntersection(t *testing.T) {
+	intersectionTests := []struct {
+		charts   repo.ChartVersions
+		expected []string
+	}{
+		{nil, []string{}},
+		{
+			repo.ChartVersions{
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Keywords: []string{},
+					},
+				},
+			},
+			[]string{},
+		},
+		{
+			repo.ChartVersions{
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Keywords: []string{"foo", "bar"},
+					},
+				},
+			},
+			[]string{"foo", "bar"}},
+		{
+			repo.ChartVersions{
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Keywords: []string{"foo", "bar"},
+					},
+				},
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Keywords: []string{"baz", "foo"},
+					},
+				},
+			},
+			[]string{"foo"}},
+	}
+
+	for _, tt := range intersectionTests {
+		actual := getTagIntersection(tt.charts)
+
+		if len(actual) != len(tt.expected) {
+			t.Errorf("getTagIntersection(%v): expected %v, actual %v",
+				tt.charts, tt.expected, actual)
+
+			break
+		}
+
+		for index, keyword := range actual {
+			if keyword != tt.expected[index] {
+				t.Errorf("getTagIntersection(%v): expected %v, actual %v",
+					tt.charts, tt.expected, actual)
+			}
+		}
+	}
+}


### PR DESCRIPTION
CF apps [look for service tags](https://github.com/pivotal-cf/cf-redis-example-app/blob/4041cc349fc1535385d12b68264e70de5f49a347/lib/app.rb#L73) to use services. Helm charts [provide keywords](https://github.com/kubernetes/charts/blob/fd35ab34bfd26878fb5970fbc7c3e75760df10ec/stable/redis/Chart.yaml#L6) that can be used as these tags.

This PR adds the tags to the [Service object](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-object) in the OSB API.

This saves a step in app deployment in CF. Currently a deployment looks like this:

```
cd cf-example-redis-app
cf push --no-start
cf set-env redis-example-app service_name r
cf bind-service redis-example-app r
cf start redis-example-app
```

By using tags, we can skip the `set-env` step.

Unfortunately the helm charts provide keywords *per chart*, but CF uses tags *per service*. I decided to take the intersection of the keywords to be sure that all plans in the service will support the keyword.

