### PR TITLE
Fix stable/postgresql chart support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-postgresql: setup-postgresql teardown-postgresql
 setup-postgresql:
 	until svcat get broker minibroker | grep -m 1 Ready; do : ; done
 
-	svcat provision postgresql --class postgresql --plan 9-6-2 --namespace minibroker \
+	svcat provision postgresql --class postgresql --plan 11-0-0 --namespace minibroker \
 		-p postgresDatabase=mydb -p postgresUser=admin
 	until svcat get instance postgresql -n minibroker | grep -m 1 Ready; do : ; done
 	svcat get instance postgresql -n minibroker
@@ -75,8 +75,8 @@ setup-postgresql:
 	svcat describe binding postgresql -n minibroker
 
 teardown-postgresql:
-	svcat unbind postgresql
-	svcat deprovision postgresql
+	svcat unbind postgresql -n minibroker
+	svcat deprovision postgresql -n minibroker
 
 test-mongodb: setup-mongodb teardown-mongodb
 

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -32,7 +32,13 @@ func (p PostgresProvider) Bind(services []corev1.Service, params map[string]inte
 
 	passwordVal, ok := chartSecrets["postgres-password"]
 	if !ok {
-		return nil, errors.Errorf("postgres-password not found in secret keys")
+		// Chart versions 2.0+ use postgresqlPassword instead of postresPassword
+		// See https://github.com/osbkit/minibroker/issues/17
+		passwordVal, ok = chartSecrets["postgresql-password"]
+
+		if !ok {
+			return nil, errors.Errorf("neither postgres-password nor postgresql-password not found in secret keys")
+		}
 	}
 	password = passwordVal.(string)
 


### PR DESCRIPTION
After version 2.0+ the password is stored in `postgresqlPassword` instead of `postgresqlPassword`. I've updated the code to look in both places.

I've also updated the test to install the latest available chart version of postgres to test out the fix.

Fixes #17.