### PR TITLE
adding suse registry for container images

### DIFF
--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for the minibroker
 # Image to use
-image: osbkit/minibroker:latest
+image: cap/minibroker:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 deploymentPolicy: RollingUpdate
@@ -12,3 +12,11 @@ tls:
   key:
 
 serviceCatalogEnabledOnly: true
+
+# Setting default registry to SUSE
+kube:
+  registry:
+    hostname: registry.suse.com
+    username: ""
+    password: ""
+  organization: cap


### PR DESCRIPTION
**DO NOT MERGE**

This PR specifies SUSE Registry to be used for container images instead of DockerHub.

**Note:** This PR should only be merged once:
1. This PR is merged and tested: https://github.com/SUSE/cloudfoundry/pull/102
2. @thardeck releases container images to `registry.suse.com`

Details: https://trello.com/c/3oq0Yimf/919-host-minibroker-images-on-registrysusecom