### PR TITLE
Switch to quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPO ?= github.com/osbkit/minibroker
 BINARY ?= minibroker
 PKG ?= $(REPO)/cmd/$(BINARY)
-REGISTRY ?= osbkit/
+REGISTRY ?= quay.io/kubernetes-service-catalog/
 IMAGE ?= $(REGISTRY)minibroker
 TAG ?= canary
 

--- a/build/publish-images.sh
+++ b/build/publish-images.sh
@@ -2,11 +2,12 @@
 
 set -euo pipefail
 
-IMAGE=${IMAGE:-osbkit/minibroker}
+SERVER=${SERVER:-quay.io}
+IMAGE=${IMAGE:-quay.io/kubernetes-service-catalog/minibroker}
 TAG=${TAG:-canary}
 
 if [[ -v DOCKER_PASSWORD && -v DOCKER_USERNAME ]]; then
-    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $SERVER
 fi
 
 docker push "$IMAGE:$TAG"

--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for the minibroker
 # Image to use
-image: osbkit/minibroker:v0.3.1
+image: quay.io/kubernetes-service-catalog/minibroker:canary
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 deploymentPolicy: RollingUpdate


### PR DESCRIPTION
Publish the minibroker image to quay because there is better security
there. After the docker security breach it became clear that using my
own personal login for our CI wasn't acceptable, and quay lets me make
robot accounts easily.

This also sets us up to migrate the repository to kubernetes-sigs where
they publish to quay anyway.